### PR TITLE
core: reuse buffer-cursors in process-each-cursors

### DIFF
--- a/src/command-advices.lisp
+++ b/src/command-advices.lisp
@@ -5,16 +5,24 @@
 (defclass editable-advice () ())
 
 ;;; multiple cursors
-(defun process-each-cursors (function)
-  (let ((buffer (current-buffer)))
-    (dolist (point (sort (copy-list (buffer-fake-cursors buffer)) #'point<))
-      (with-buffer-point (buffer point)
-        (with-current-killring (fake-cursor-killring point)
-          (handler-case
-              (save-continue-flags
-                (funcall function))
-            (move-cursor-error ())))))
-    (funcall function)))
+(defun process-each-cursors (fn)
+  (let* ((buffer (current-buffer))
+         (current (buffer-point buffer))
+         (cursors (buffer-cursors buffer)))
+    (declare (type function fn)
+             (type lem:buffer buffer)
+             (type lem/buffer/internal:point current)
+             (type (list lem:cursor) cursors)
+             (optimize (speed 3) (safety 2)))
+    (dolist (point cursors)
+      (unless (eq point current)            ; skip the real cursor
+        (with-buffer-point (buffer point)
+          (with-current-killring (fake-cursor-killring point)
+            (handler-case
+                (save-continue-flags
+                  (funcall fn))
+              (move-cursor-error ()))))))
+    (funcall fn)))
 
 (defmacro do-each-cursors (() &body body)
   `(process-each-cursors (lambda () ,@body)))


### PR DESCRIPTION
## Summary
- optimize `process-each-cursors` by caching `buffer-cursors` and adding type/optimization declarations
- specify precise buffer, point, and cursor types and note skipping the real cursor
- rename callback argument to `fn` and declare its function type

## Testing
- `make test` *(fails: qlot: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689262c58abc8333bdce01c76a383c12